### PR TITLE
Update cluster-api app to 1.9.1

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.7.0
+app_version: 1.9.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
I tested this version on `gerkan` and it is compatible with our latest cluster-vsphere version.

Note that, we don't have automation for the cluster-api app for other providers too. Provider maintainers are supposed to update the version of this app.