### PR TITLE
capi 1.16.0

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.16.0
+app_version: 1.17.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
[PR](https://github.com/giantswarm/cluster-api-app/pull/202) to update cluster-api-app  to CAPI v1.4.9 which addresses issues when updating kubeadmConfigSpec joinConfiguration fields