### PR TITLE
push alloy-gateway to collection

### DIFF
--- a/flux-manifests/alloy-gateway.yaml
+++ b/flux-manifests/alloy-gateway.yaml
@@ -1,0 +1,13 @@
+api_version: generators.giantswarm.io/v1
+app_catalog: control-plane-catalog
+app_destination_namespace: monitoring
+app_name: alloy-gateway
+app_version: 0.5.2
+kind: Konfigure
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      exec:
+        path: /plugins/konfigure
+  name: alloy-gateway
+name: alloy-gateway

--- a/flux-manifests/kustomization.yaml
+++ b/flux-manifests/kustomization.yaml
@@ -1,4 +1,5 @@
 generators:
+- alloy-gateway.yaml
 - app-admission-controller.yaml
 - app-exporter.yaml
 - app-operator.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3568


This PR adds a new component in our MC to be able to receive logs from outside the clusters. It currently does nothing as the config disables it anyway but this will be used to ingest customer logs as well as teleport logs 